### PR TITLE
Fix: write to file should handle bytes

### DIFF
--- a/diagram.py
+++ b/diagram.py
@@ -1241,7 +1241,7 @@ def run():
         except AttributeError:
             ostream = sys.stdout
     else:
-        ostream = open(option.output, 'r')
+        ostream = open(option.output, 'wb')
 
     option.encoding = option.encoding or Terminal().encoding
 


### PR DESCRIPTION
The previous code uses 'r' which I believe is a typo
