### PR TITLE
Add default y_axis to DOption

### DIFF
--- a/diagram.py
+++ b/diagram.py
@@ -1268,6 +1268,7 @@ class DOption(object):
         self.mode = 'v'
         self.axis = True
         self.keys = False
+        self.y_axis = None
 
         # Make graph look 'ok' instead of crashing on MS windows
         import platform


### PR DESCRIPTION
This fixes #26 by adding `y_axis` of `None` to `DOption`.